### PR TITLE
Avoid allocation in map_fds.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub struct FdMappingCollision;
 
 /// Extension to add file descriptor mappings to a [`Command`].
 pub trait CommandFdExt {
-    /// Adds the given set of file descriptor to the command.
+    /// Adds the given set of file descriptors to the command.
     ///
     /// Calling this more than once on the same command may result in unexpected behaviour.
     fn fd_mappings(&mut self, mappings: Vec<FdMapping>) -> Result<&mut Self, FdMappingCollision>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,7 @@ mod tests {
         let file1 = File::open("testdata/file1.txt").unwrap();
         let file2 = File::open("testdata/file2.txt").unwrap();
         let fd1 = file1.as_raw_fd();
-        // Map files to each other's FDs, to ensure that the temporary FD logic works.
+        // Map file1 to the same FD it currently has, to ensure the special case for that works.
         assert!(command
             .fd_mappings(vec![FdMapping {
                 parent_fd: fd1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,8 @@ pub struct FdMappingCollision;
 pub trait CommandFdExt {
     /// Adds the given set of file descriptors to the command.
     ///
-    /// Calling this more than once on the same command may result in unexpected behaviour.
+    /// Warning: Calling this more than once on the same command, or attempting to run the same
+    /// command more than once after calling this, may result in unexpected behaviour.
     fn fd_mappings(&mut self, mappings: Vec<FdMapping>) -> Result<&mut Self, FdMappingCollision>;
 
     /// Adds the given set of file descriptors to be passed on to the child process when the command
@@ -100,6 +101,10 @@ impl CommandFdExt for Command {
         // Register the callback to apply the mappings after forking but before execing.
         // Safety: `map_fds` will not allocate, so it is safe to call from this hook.
         unsafe {
+            // If the command is run more than once, and hence this closure is called multiple
+            // times, then `mappings` may be in an incorrect state. It would be good if we could
+            // reset it to the initial state somehow, or use something else for saving the temporary
+            // mappings.
             self.pre_exec(move || map_fds(&mut mappings, &child_fds));
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,12 +141,13 @@ fn map_fds(mappings: &[FdMapping]) -> io::Result<()> {
     // Now we can actually duplicate FDs to the desired child FDs.
     for mapping in mappings {
         if mapping.child_fd == mapping.parent_fd {
-            // Remove the FD_CLOEXEC flag, so the FD will be kept open when exec is called for the child.
+            // Remove the FD_CLOEXEC flag, so the FD will be kept open when exec is called for the
+            // child.
             fcntl(mapping.parent_fd, FcntlArg::F_SETFD(FdFlag::empty()))
                 .map_err(nix_to_io_error)?;
         } else {
-            // This closes child_fd if it is already open as something else, and clears the FD_CLOEXEC
-            // flag on child_fd.
+            // This closes child_fd if it is already open as something else, and clears the
+            // FD_CLOEXEC flag on child_fd.
             dup2(mapping.parent_fd, mapping.child_fd).map_err(nix_to_io_error)?;
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@ impl CommandFdExt for Command {
     }
 }
 
+// This function must not do any allocation, as it is called from the pre_exec hook.
 fn map_fds(mappings: &mut [FdMapping], child_fds: &[RawFd]) -> io::Result<()> {
     if mappings.is_empty() {
         // No need to do anything, and finding first_unused_fd would fail.


### PR DESCRIPTION
Allocating during a pre_exec hook may cause a deadlock.