### PR TITLE
Upgrade to nix-0.22.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ keywords = ["command", "process", "child", "subprocess", "fd"]
 categories = ["os::unix-apis"]
 
 [dependencies]
-nix = "0.20.0"
+nix = "0.22.0"
 thiserror = "1.0.24"


### PR DESCRIPTION
The nix upgrade changes nix::Error to implement Into<std::io::Error>,
which removes the need for this crate to do that on its own.
https://github.com/nix-rust/nix/pull/1446 has more details.